### PR TITLE
Check payload from inverter is empty before updating values

### DIFF
--- a/drivers/inverter/device.js
+++ b/drivers/inverter/device.js
@@ -85,6 +85,10 @@ class Inverter extends FroniusDevice {
     }
 
     updateValues(data) {
+        if (Object.keys(data).length === 0) {
+            throw new Error('No data received from inverter');
+        }
+
         //AC Energy in kWh ; default to 0
         if (this.hasCapability('meter_power'))
             this.setCapabilityValue('meter_power', typeof data.DAY_ENERGY == 'undefined' ? 0 : data.DAY_ENERGY.Value / 1000).catch(this.error);


### PR DESCRIPTION
Checking for the payload actually contains something fixes my issue. No more all values goes to zero and then back up again.

Suggestion that fixes issue #67
