### PR TITLE
fix: replace batteries config with homeBattery flag

### DIFF
--- a/drivers/GEN24-storage/driver.compose.json
+++ b/drivers/GEN24-storage/driver.compose.json
@@ -3,7 +3,7 @@
 	"name": {
 		"en": "GEN24-storage"
 	},
-	"class": "solarpanel",
+	"class": "battery",
 	"capabilities": ["measure_battery", "battery_mode"],
 	"deprecated": true,
 	"capabilitiesOptions": {
@@ -15,7 +15,7 @@
 		}
 	},
 	"energy": {
-		"batteries": ["INTERNAL"]
+		"homeBattery": true
 	},
 	"images": {
 		"large": "/drivers/GEN24-storage/assets/images/large.png",


### PR DESCRIPTION
Fixes battery configuration in GEN24-storage driver as discussed in #72

### Changes
- Removed `"batteries": ["INTERNAL"]` configuration (not needed with homeBattery)
- Changed device class from "solarpanel" to "battery"
- Added `"homeBattery": true` flag for proper Homey Energy integration

The `homeBattery: true` flag is the modern way to mark a device as a home battery, making the older `batteries` configuration redundant.

Closes #72

🤖 Generated with [Claude Code](https://claude.ai/code)