### PR TITLE
fix: remove deprecated meter_power capability from Storage devices

### DIFF
--- a/drivers/storage/device.js
+++ b/drivers/storage/device.js
@@ -14,6 +14,14 @@ class StorageDevice extends FroniusDevice {
 			this.addCapability("battery_charging_state");
 		}
 
+		// Remove deprecated meter_power capability
+		if (this.hasCapability("meter_power")) {
+			console.log(
+				`Removing deprecated capability meter_power from device ${this.getName()}`,
+			);
+			this.removeCapability("meter_power");
+		}
+
 		// Enable device polling
 		this.polling = true;
 		this.addListener("poll", this.pollDevice);


### PR DESCRIPTION
This fix adds a capability check in the Storage device's onInit() method to remove the deprecated meter_power capability from existing devices. This prevents the 'Invalid Capability: meter_power' error when devices try to update values after the capability was removed from the driver configuration.

The implementation follows the same pattern used in the Inverter driver.

Fixes #81