### PR TITLE
fix: remove underscore prefix from doSubmit function in pairing HTML files

### DIFF
--- a/drivers/GEN24-storage/pair/enter_ip.html
+++ b/drivers/GEN24-storage/pair/enter_ip.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     Homey.setTitle("Specificy Fronius Datamanager IP/hostname");
 
-    function _doSubmit(){
+    function doSubmit(){
         const hostname = document.getElementById('hostname').value;
         if(!hostname){
             Homey.alert('Please fill in all fields');

--- a/drivers/fronius-powerflow/pair/enter_values.html
+++ b/drivers/fronius-powerflow/pair/enter_values.html
@@ -10,7 +10,7 @@
         return `${s4() + s4()}-${s4()}-${s4()}-${s4()}-${s4()}${s4()}${s4()}`;
     }
 
-    function _doSubmit(){
+    function doSubmit(){
         const hostname = document.getElementById('hostname').value;
         const name = document.getElementById('name').value;
 

--- a/drivers/inverter/pair/enter_ip.html
+++ b/drivers/inverter/pair/enter_ip.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     Homey.setTitle("Specificy Fronius Datamanager IP/hostname");
 
-    function _doSubmit(){
+    function doSubmit(){
         const hostname = document.getElementById('hostname').value;
         if(!hostname){
             Homey.alert('Please fill in all fields');

--- a/drivers/ohmpilot/pair/enter_ip.html
+++ b/drivers/ohmpilot/pair/enter_ip.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     Homey.setTitle("Specificy Fronius Datamanager IP/hostname");
 
-    function _doSubmit(){
+    function doSubmit(){
         const hostname = document.getElementById('hostname').value;
         if(!hostname){
             Homey.alert('Please fill in all fields');

--- a/drivers/reporting/pair/enter_values.html
+++ b/drivers/reporting/pair/enter_values.html
@@ -10,7 +10,7 @@
         return `${s4() + s4()}-${s4()}-${s4()}-${s4()}-${s4()}${s4()}${s4()}`;
     }
 
-    function _doSubmit(){
+    function doSubmit(){
         const hostname = document.getElementById('hostname').value;
         const name = document.getElementById('name').value;
 

--- a/drivers/smartmeter/pair/enter_ip.html
+++ b/drivers/smartmeter/pair/enter_ip.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     Homey.setTitle("Specificy Fronius Datamanager IP/hostname");
 
-    function _doSubmit(){
+    function doSubmit(){
         const hostname = document.getElementById('hostname').value;
         if(!hostname){
             Homey.alert('Please fill in all fields');

--- a/drivers/storage/pair/enter_ip.html
+++ b/drivers/storage/pair/enter_ip.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     Homey.setTitle("Specificy Fronius Datamanager IP/hostname");
 
-    function _doSubmit(){
+    function doSubmit(){
         const hostname = document.getElementById('hostname').value;
         if(!hostname){
             Homey.alert('Please fill in all fields');


### PR DESCRIPTION
Fixes device pairing issue where the linter added underscore prefixes to doSubmit functions, but the onclick handlers called doSubmit() without the underscore.

This was causing ReferenceError and preventing users from adding new devices.

Fixes #84

Generated with [Claude Code](https://claude.ai/code)