### PR TITLE
Fix cumulative energy not showing up

### DIFF
--- a/app.json
+++ b/app.json
@@ -653,8 +653,8 @@
         "measure_current",
         "measure_voltage",
         "measure_frequency",
-        "meter_power",
-        "meter_power.injected",
+        "meter_power.imported",
+        "meter_power.exported",
         "measure_current.phase1",
         "measure_current.phase2",
         "measure_current.phase3"
@@ -665,7 +665,7 @@
             "en": "Energy consumed"
           }
         },
-        "meter_power.injected": {
+        "meter_power.exported": {
           "title": {
             "en": "Energy injected"
           }
@@ -703,10 +703,8 @@
       },
       "energy": {
         "cumulative": true,
-        "cumulativeImportedCapability": "meter_power",
-        "cumulativeExportedCapability": "meter_power.injected",
-        "meterPowerImportedCapability": "meter_power",
-        "meterPowerExportedCapability": "meter_power.injected"
+        "cumulativeImportedCapability": "meter_power.imported",
+        "cumulativeExportedCapability": "meter_power.exported"
       },
       "images": {
         "large": "/drivers/smartmeter/assets/images/large.png",

--- a/app.json
+++ b/app.json
@@ -232,6 +232,9 @@
         "meter_power.YEAR",
         "meter_power.TOTAL"
       ],
+      "energy": {
+        "meterPowerExportedCapability": "meter_power.TOTAL"
+      },
       "capabilitiesOptions": {
         "meter_power": {
           "title": {
@@ -701,7 +704,9 @@
       "energy": {
         "cumulative": true,
         "cumulativeImportedCapability": "meter_power",
-        "cumulativeExportedCapability": "meter_power.injected"
+        "cumulativeExportedCapability": "meter_power.injected",
+        "meterPowerImportedCapability": "meter_power",
+        "meterPowerExportedCapability": "meter_power.injected"
       },
       "images": {
         "large": "/drivers/smartmeter/assets/images/large.png",

--- a/drivers/inverter/driver.compose.json
+++ b/drivers/inverter/driver.compose.json
@@ -21,6 +21,9 @@
 		"meter_power.YEAR",
 		"meter_power.TOTAL"
 	],
+	"energy": {
+		"meterPowerExportedCapability": "meter_power.TOTAL"
+	},
 	"capabilitiesOptions": {
 		"meter_power": {
 			"title": { "en": "Daily Production" }

--- a/drivers/smartmeter/device.js
+++ b/drivers/smartmeter/device.js
@@ -97,19 +97,19 @@ class Smartmeter extends FroniusDevice {
 	updateValues(data) {
 		if (!this.getSetting("gen24meterbug")) {
 			//Consumed Energy in kWh ; default to 0 ; should be given by EnergyReal_WAC_Plus_Absolute
-			this.setCapabilityValue(
-				"meter_power",
-				typeof data.EnergyReal_WAC_Plus_Absolute === "undefined"
+			const imported_energy = typeof data.EnergyReal_WAC_Plus_Absolute === "undefined"
 					? 0
-					: data.EnergyReal_WAC_Plus_Absolute / 1000,
-			);
+					: data.EnergyReal_WAC_Plus_Absolute / 1000;
+			this.setCapabilityValue("meter_power.imported", imported_energy).catch(() => {
+				this.setCapabilityValue("meter_power", imported_energy);
+			});
 			//Injected energy ; EnergyReal_WAC_Minus_Absolute
-			this.setCapabilityValue(
-				"meter_power.injected",
-				typeof data.EnergyReal_WAC_Minus_Absolute === "undefined"
+			const exported_energy = typeof data.EnergyReal_WAC_Minus_Absolute === "undefined"
 					? 0
-					: data.EnergyReal_WAC_Minus_Absolute / 1000,
-			);
+					: data.EnergyReal_WAC_Minus_Absolute / 1000;
+			this.setCapabilityValue("meter_power.exported", exported_energy).catch(() => {
+				this.setCapabilityValue("meter_power.injected", exported_energy);
+			});
 
 			//power, in W ; default to 0
 			this.setCapabilityValue(
@@ -185,19 +185,19 @@ class Smartmeter extends FroniusDevice {
 			//workaround for strange field values in some GEN24 firmware
 
 			//Consumed Energy in kWh ; default to 0 ; should be given by EnergyReal_WAC_Plus_Absolute
-			this.setCapabilityValue(
-				"meter_power",
-				typeof data.SMARTMETER_ENERGYACTIVE_ABSOLUT_PLUS_F64 === "undefined"
+			const imported_energy = typeof data.SMARTMETER_ENERGYACTIVE_ABSOLUT_PLUS_F64 === "undefined"
 					? 0
-					: data.SMARTMETER_ENERGYACTIVE_ABSOLUT_PLUS_F64 / 1000,
-			);
+					: data.SMARTMETER_ENERGYACTIVE_ABSOLUT_PLUS_F64 / 1000;
+			this.setCapabilityValue("meter_power.imported", imported_energy).catch(() => {
+				this.setCapabilityValue("meter_power", imported_energy);
+			});
 			//Injected energy ; EnergyReal_WAC_Minus_Absolute
-			this.setCapabilityValue(
-				"meter_power.injected",
-				typeof data.SMARTMETER_ENERGYACTIVE_ABSOLUT_MINUS_F64 === "undefined"
+			const exported_energy = typeof data.SMARTMETER_ENERGYACTIVE_ABSOLUT_MINUS_F64 === "undefined"
 					? 0
-					: data.SMARTMETER_ENERGYACTIVE_ABSOLUT_MINUS_F64 / 1000,
-			);
+					: data.SMARTMETER_ENERGYACTIVE_ABSOLUT_MINUS_F64 / 1000;
+			this.setCapabilityValue("meter_power.exported", exported_energy).catch(() => {
+				this.setCapabilityValue("meter_power.injected", exported_energy);
+			});
 
 			//power, in W ; default to 0
 			this.setCapabilityValue(

--- a/drivers/smartmeter/driver.compose.json
+++ b/drivers/smartmeter/driver.compose.json
@@ -44,7 +44,9 @@
 	"energy": {
 		"cumulative": true,
 		"cumulativeImportedCapability": "meter_power",
-		"cumulativeExportedCapability": "meter_power.injected"
+		"cumulativeExportedCapability": "meter_power.injected",
+		"meterPowerImportedCapability": "meter_power",
+		"meterPowerExportedCapability": "meter_power.injected"
 	},
 	"images": {
 		"large": "/drivers/smartmeter/assets/images/large.png",

--- a/drivers/smartmeter/driver.compose.json
+++ b/drivers/smartmeter/driver.compose.json
@@ -9,8 +9,8 @@
 		"measure_current",
 		"measure_voltage",
 		"measure_frequency",
-		"meter_power",
-		"meter_power.injected",
+		"meter_power.imported",
+		"meter_power.exported",
 		"measure_current.phase1",
 		"measure_current.phase2",
 		"measure_current.phase3"
@@ -19,7 +19,7 @@
 		"meter_power": {
 			"title": { "en": "Energy consumed" }
 		},
-		"meter_power.injected": {
+		"meter_power.exported": {
 			"title": { "en": "Energy injected" }
 		},
 		"measure_current": {
@@ -43,10 +43,8 @@
 	},
 	"energy": {
 		"cumulative": true,
-		"cumulativeImportedCapability": "meter_power",
-		"cumulativeExportedCapability": "meter_power.injected",
-		"meterPowerImportedCapability": "meter_power",
-		"meterPowerExportedCapability": "meter_power.injected"
+		"cumulativeImportedCapability": "meter_power.imported",
+		"cumulativeExportedCapability": "meter_power.exported"
 	},
 	"images": {
 		"large": "/drivers/smartmeter/assets/images/large.png",

--- a/drivers/smartmeter/driver.js
+++ b/drivers/smartmeter/driver.js
@@ -27,8 +27,8 @@ function froniusToDevice(json, ip, DeviceId) {
 			"measure_current",
 			"measure_voltage",
 			"measure_frequency",
-			"meter_power",
-			"meter_power.injected",
+			"meter_power.imported",
+			"meter_power.exported",
 		],
 	};
 	console.log(device);

--- a/tests/drivers/smartmeter/device.test.js
+++ b/tests/drivers/smartmeter/device.test.js
@@ -12,8 +12,8 @@ class TestSmartmeter extends Smartmeter {
 			"measure_current",
 			"measure_voltage",
 			"measure_frequency",
-			"meter_power",
-			"meter_power.injected",
+			"meter_power.imported",
+			"meter_power.exported",
 		]);
 		this._capabilityValues = new Map();
 		this._settings = {
@@ -170,8 +170,8 @@ describe("Smartmeter", () => {
 
 			device.updateValues(data);
 
-			expect(device.getCapabilityValue("meter_power")).toBe(5000);
-			expect(device.getCapabilityValue("meter_power.injected")).toBe(2000);
+			expect(device.getCapabilityValue("meter_power.imported")).toBe(5000);
+			expect(device.getCapabilityValue("meter_power.exported")).toBe(2000);
 			expect(device.getCapabilityValue("measure_power")).toBe(1500);
 			expect(device.getCapabilityValue("measure_current")).toBe(6.5);
 			expect(device.getCapabilityValue("measure_voltage")).toBe(230);
@@ -242,8 +242,8 @@ describe("Smartmeter", () => {
 
 			device.updateValues(data);
 
-			expect(device.getCapabilityValue("meter_power")).toBe(0);
-			expect(device.getCapabilityValue("meter_power.injected")).toBe(0);
+			expect(device.getCapabilityValue("meter_power.imported")).toBe(0);
+			expect(device.getCapabilityValue("meter_power.exported")).toBe(0);
 			expect(device.getCapabilityValue("measure_power")).toBe(0);
 			expect(device.getCapabilityValue("measure_current")).toBe(0);
 			expect(device.getCapabilityValue("measure_voltage")).toBe(0);
@@ -318,8 +318,8 @@ describe("Smartmeter", () => {
 
 			device.updateValues(data);
 
-			expect(device.getCapabilityValue("meter_power")).toBe(5000);
-			expect(device.getCapabilityValue("meter_power.injected")).toBe(2000);
+			expect(device.getCapabilityValue("meter_power.imported")).toBe(5000);
+			expect(device.getCapabilityValue("meter_power.exported")).toBe(2000);
 			expect(device.getCapabilityValue("measure_power")).toBe(1500);
 			expect(device.getCapabilityValue("measure_frequency")).toBe(50.02);
 		});
@@ -367,8 +367,8 @@ describe("Smartmeter", () => {
 
 			device.updateValues(data);
 
-			expect(device.getCapabilityValue("meter_power")).toBe(0);
-			expect(device.getCapabilityValue("meter_power.injected")).toBe(0);
+			expect(device.getCapabilityValue("meter_power.imported")).toBe(0);
+			expect(device.getCapabilityValue("meter_power.exported")).toBe(0);
 			expect(device.getCapabilityValue("measure_power")).toBe(0);
 			expect(device.getCapabilityValue("measure_frequency")).toBe(0);
 		});
@@ -384,8 +384,8 @@ describe("Smartmeter", () => {
 
 			device.updateValues(data);
 
-			expect(device.getCapabilityValue("meter_power")).toBe(0);
-			expect(device.getCapabilityValue("meter_power.injected")).toBe(0);
+			expect(device.getCapabilityValue("meter_power.imported")).toBe(0);
+			expect(device.getCapabilityValue("meter_power.exported")).toBe(0);
 			expect(device.getCapabilityValue("measure_power")).toBe(0);
 		});
 
@@ -408,7 +408,7 @@ describe("Smartmeter", () => {
 
 			device.updateValues(data);
 
-			expect(device.getCapabilityValue("meter_power")).toBe(100000);
+			expect(device.getCapabilityValue("meter_power.imported")).toBe(100000);
 		});
 	});
 });


### PR DESCRIPTION
This should fix #64 (cumulative energy not showing up in energy) for the _smart meter_ and the _inverter_ class.

For the inverter, the `meter_power` to track was set to the daily values. However my Gen 24 doesn't report a daily accumulated value. I guess there are more inverters which report only the total energy than such reporting only the daily energy (if there are any at all). For me, the most minimal fix was to change `meterPowerExportedCapability`(defaulting to `meter_power` and thus the daily values) to point to `meter_power.TOTAL`.

For the smart meter, it unfortunately isn't as easy. I tried adding `meterPowerImportedCapability` and `meterPowerExportedCapability`, but that in the end didn't help. What fixed it was renaming the capabilities `meter_power`->`meter_power.imported` and `meter_power.injected`->`meter_power.exported`. I have no clue which properties depend on these suffixes. Unfortunately, so far only reinstalling the device updates the capabilities.