### PR TITLE
Fix cumulative energy

### DIFF
--- a/app.json
+++ b/app.json
@@ -232,6 +232,9 @@
         "meter_power.YEAR",
         "meter_power.TOTAL"
       ],
+      "energy": {
+        "meterPowerExportedCapability": "meter_power.TOTAL"
+      },
       "capabilitiesOptions": {
         "meter_power": {
           "title": {

--- a/drivers/inverter/driver.compose.json
+++ b/drivers/inverter/driver.compose.json
@@ -21,6 +21,9 @@
 		"meter_power.YEAR",
 		"meter_power.TOTAL"
 	],
+	"energy": {
+		"meterPowerExportedCapability": "meter_power.TOTAL"
+	},
 	"capabilitiesOptions": {
 		"meter_power": {
 			"title": { "en": "Daily Production" }

--- a/drivers/smartmeter/device.js
+++ b/drivers/smartmeter/device.js
@@ -85,7 +85,13 @@ class Smartmeter extends FroniusDevice {
 			}
 		}
 
-		this.setEnergy({ cumulative: newSettings.cumulative }).then(
+		this.setEnergy({
+			cumulative: newSettings.cumulative,
+			cumulativeImportedCapability: "meter_power",
+			cumulativeExportedCapability: "meter_power.injected",
+			meterPowerImportedCapability: "meter_power",
+			meterPowerExportedCapability: "meter_power.injected",
+		}).then(
 			this.updateFroniusDevice(),
 		);
 	}

--- a/drivers/smartmeter/driver.js
+++ b/drivers/smartmeter/driver.js
@@ -30,13 +30,6 @@ function froniusToDevice(json, ip, DeviceId) {
 			"meter_power",
 			"meter_power.injected",
 		],
-		energy: {
-			cumulative: true,
-			cumulativeImportedCapability: "meter_power",
-			cumulativeExportedCapability: "meter_power.injected",
-			meterPowerImportedCapability: "meter_power",
-			meterPowerExportedCapability: "meter_power.injected",
-		},
 	};
 	console.log(device);
 	return device;

--- a/drivers/smartmeter/driver.js
+++ b/drivers/smartmeter/driver.js
@@ -30,6 +30,13 @@ function froniusToDevice(json, ip, DeviceId) {
 			"meter_power",
 			"meter_power.injected",
 		],
+		energy: {
+			cumulative: true,
+			cumulativeImportedCapability: "meter_power",
+			cumulativeExportedCapability: "meter_power.injected",
+			meterPowerImportedCapability: "meter_power",
+			meterPowerExportedCapability: "meter_power.injected",
+		},
 	};
 	console.log(device);
 	return device;


### PR DESCRIPTION
This should fix #64 (cumulative energy not showing up in energy) for the _smart meter_ and the _inverter_ class.

For the inverter, the `meter_power` to track was set to the daily values. However my Gen 24 doesn't report a daily accumulated value. I guess there are more inverters which report only the total energy than such reporting only the daily energy (if there are any at all). For me, the most minimal fix was to change `meterPowerExportedCapability`(defaulting to `meter_power` and thus the daily values) to point to `meter_power.TOTAL`.

**UPDATE:**
For the smart meter, it also needs `meterPowerImported/ExportedCapability`. By default they seem to point to `meter_power.imported/exported`
The smart meter driver calls `this.setEnergy` whenever settings change, but then only supplies `{cumulative: ...}`. This seems to reset the values for `cumulativeImported/ExportedCapability` and `meterPowerImported/ExportedCapability`.