### PR TITLE
Add new capabilities for inverter and powerflow

### DIFF
--- a/.homeycompose/capabilities/fronius_autonomy.json
+++ b/.homeycompose/capabilities/fronius_autonomy.json
@@ -1,0 +1,14 @@
+{
+	"type": "number",
+	"title": {
+		"en": "Autonomy"
+	},
+	"getable": true,
+	"setable": false,
+	"icon": "/assets/selfconsumption.svg",
+	"insights": true,
+	"units": {
+		"en": "%"
+	},
+	"decimals": 1
+}

--- a/.homeycompose/capabilities/fronius_backup_mode.json
+++ b/.homeycompose/capabilities/fronius_backup_mode.json
@@ -1,0 +1,10 @@
+{
+	"type": "boolean",
+	"title": {
+		"en": "Backup mode"
+	},
+	"getable": true,
+	"setable": false,
+	"icon": "/assets/information.svg",
+	"insights": true
+}

--- a/.homeycompose/capabilities/fronius_error_code.json
+++ b/.homeycompose/capabilities/fronius_error_code.json
@@ -1,0 +1,9 @@
+{
+	"type": "string",
+	"title": {
+		"en": "Error code"
+	},
+	"getable": true,
+	"setable": false,
+	"icon": "/assets/information.svg"
+}

--- a/.homeycompose/capabilities/fronius_inverter_state.json
+++ b/.homeycompose/capabilities/fronius_inverter_state.json
@@ -1,0 +1,9 @@
+{
+	"type": "string",
+	"title": {
+		"en": "Inverter state"
+	},
+	"getable": true,
+	"setable": false,
+	"icon": "/assets/information.svg"
+}

--- a/.homeycompose/capabilities/fronius_self_consumption.json
+++ b/.homeycompose/capabilities/fronius_self_consumption.json
@@ -1,0 +1,14 @@
+{
+	"type": "number",
+	"title": {
+		"en": "Self-consumption"
+	},
+	"getable": true,
+	"setable": false,
+	"icon": "/assets/selfconsumption.svg",
+	"insights": true,
+	"units": {
+		"en": "%"
+	},
+	"decimals": 1
+}

--- a/app.json
+++ b/app.json
@@ -139,7 +139,10 @@
         "measure_power.PV",
         "measure_power.GRID",
         "measure_power.LOAD",
-        "measure_power.AKKU"
+        "measure_power.AKKU",
+        "fronius_backup_mode",
+        "fronius_autonomy",
+        "fronius_self_consumption"
       ],
       "capabilitiesOptions": {
         "measure_power.PV": {
@@ -160,6 +163,21 @@
         "measure_power.AKKU": {
           "title": {
             "en": "Akku Power"
+          }
+        },
+        "fronius_backup_mode": {
+          "title": {
+            "en": "Backup mode"
+          }
+        },
+        "fronius_autonomy": {
+          "title": {
+            "en": "Autonomy"
+          }
+        },
+        "fronius_self_consumption": {
+          "title": {
+            "en": "Self-consumption"
           }
         }
       },
@@ -230,7 +248,9 @@
         "measure_frequency",
         "meter_power",
         "meter_power.YEAR",
-        "meter_power.TOTAL"
+        "meter_power.TOTAL",
+        "fronius_inverter_state",
+        "fronius_error_code"
       ],
       "capabilitiesOptions": {
         "meter_power": {
@@ -301,6 +321,16 @@
         "measure_frequency": {
           "title": {
             "en": "Phase frequency"
+          }
+        },
+        "fronius_inverter_state": {
+          "title": {
+            "en": "Inverter state"
+          }
+        },
+        "fronius_error_code": {
+          "title": {
+            "en": "Error code"
           }
         }
       },
@@ -895,6 +925,62 @@
       "getable": true,
       "setable": false,
       "icon": "/assets/information.svg"
+    },
+    "fronius_autonomy": {
+      "type": "number",
+      "title": {
+        "en": "Autonomy"
+      },
+      "getable": true,
+      "setable": false,
+      "icon": "/assets/selfconsumption.svg",
+      "insights": true,
+      "units": {
+        "en": "%"
+      },
+      "decimals": 1
+    },
+    "fronius_backup_mode": {
+      "type": "boolean",
+      "title": {
+        "en": "Backup mode"
+      },
+      "getable": true,
+      "setable": false,
+      "icon": "/assets/information.svg",
+      "insights": true
+    },
+    "fronius_error_code": {
+      "type": "string",
+      "title": {
+        "en": "Error code"
+      },
+      "getable": true,
+      "setable": false,
+      "icon": "/assets/information.svg"
+    },
+    "fronius_inverter_state": {
+      "type": "string",
+      "title": {
+        "en": "Inverter state"
+      },
+      "getable": true,
+      "setable": false,
+      "icon": "/assets/information.svg"
+    },
+    "fronius_self_consumption": {
+      "type": "number",
+      "title": {
+        "en": "Self-consumption"
+      },
+      "getable": true,
+      "setable": false,
+      "icon": "/assets/selfconsumption.svg",
+      "insights": true,
+      "units": {
+        "en": "%"
+      },
+      "decimals": 1
     },
     "measure_frequency": {
       "type": "number",

--- a/drivers/fronius-powerflow/device.js
+++ b/drivers/fronius-powerflow/device.js
@@ -2,6 +2,36 @@ import fetch from "node-fetch";
 import FroniusDevice from "../../lib/device.js";
 
 class PowerFlow extends FroniusDevice {
+	/**
+	* onInit is called when the device is initialized.
+	*/
+	async onInit() {
+	   this.log("Device has been initialized");
+
+	   if (!this.hasCapability("fronius_backup_mode")) {
+		   console.log(
+			   `Adding capability fronius_backup_mode to device ${this.getName()}`,
+		   );
+		   this.addCapability("fronius_backup_mode");
+	   }
+
+	   if (!this.hasCapability("fronius_autonomy")) {
+		console.log(
+			`Adding capability fronius_autonomy to device ${this.getName()}`,
+		);
+		this.addCapability("fronius_autonomy");
+	}
+
+	if (!this.hasCapability("fronius_self_consumption")) {
+		console.log(
+			`Adding capability fronius_self_consumption to device ${this.getName()}`,
+		);
+		this.addCapability("fronius_self_consumption");
+	}
+
+	   await super.onInit();
+   }
+
 	updateFroniusDevice() {
 		const settings = this.getSettings();
 		const updatePath = "/solar_api/v1/GetPowerFlowRealtimeData.fcgi";
@@ -42,11 +72,41 @@ class PowerFlow extends FroniusDevice {
 		this.setCapabilityValue("measure_power.GRID", pgrid);
 		this.setCapabilityValue("measure_power.AKKU", pakku);
 
+		const relAutonomy =
+			typeof data.rel_Autonomy === "undefined" || data.rel_Autonomy == null
+				? 0
+				: data.rel_Autonomy;
+		const relSelfConsumption =
+			typeof data.rel_SelfConsumption === "undefined" ||
+			data.rel_SelfConsumption == null
+				? 0
+				: data.rel_SelfConsumption;
+
+		if (this.hasCapability("fronius_autonomy")) {
+			this.setCapabilityValue("fronius_autonomy", relAutonomy);
+		}
+
+		if (this.hasCapability("fronius_self_consumption")) {
+			this.setCapabilityValue(
+				"fronius_self_consumption",
+				relSelfConsumption,
+			);
+		}
+
 		/* grid power + Akku power
       IDKW, homey adds power produced by PV in the energy tab (see for example https://github.com/DiedB/Homey-SolarPanels/issues/128)
       by using measure_power = grid power + akku power , the correct value should be displayed in energy tab assuming all PV power is used
       */
 		this.setCapabilityValue("measure_power", pgrid + pakku);
+
+		// BackupMode: true = house on backup, false = on grid (GEN24 with battery only)
+		if (this.hasCapability("fronius_backup_mode")) {
+			const backupMode =
+				typeof data.BackupMode === "boolean" ? data.BackupMode : false;
+			this.setCapabilityValue("fronius_backup_mode", backupMode).catch(
+				this.error,
+			);
+		}
 	}
 
 	async onSettings({ oldSettings, newSettings, changedKeys }) {

--- a/drivers/fronius-powerflow/driver.compose.json
+++ b/drivers/fronius-powerflow/driver.compose.json
@@ -9,7 +9,10 @@
 		"measure_power.PV",
 		"measure_power.GRID",
 		"measure_power.LOAD",
-		"measure_power.AKKU"
+		"measure_power.AKKU",
+		"fronius_backup_mode",
+		"fronius_autonomy",
+		"fronius_self_consumption"
 	],
 	"capabilitiesOptions": {
 		"measure_power.PV": {
@@ -23,6 +26,15 @@
 		},
 		"measure_power.AKKU": {
 			"title": { "en": "Akku Power" }
+		},
+		"fronius_backup_mode": {
+			"title": { "en": "Backup mode" }
+		},
+		"fronius_autonomy": {
+			"title": { "en": "Autonomy" }
+		},
+		"fronius_self_consumption": {
+			"title": { "en": "Self-consumption" }
 		}
 	},
 	"energy": {

--- a/drivers/inverter/device.js
+++ b/drivers/inverter/device.js
@@ -1,5 +1,35 @@
 import FroniusDevice from "../../lib/device.js";
 
+/** StatusCode mapping from Fronius Solar API 4.6.5 */
+const STATUS_CODE_MAP = {
+	0: "Startup",
+	1: "Startup",
+	2: "Startup",
+	3: "Startup",
+	4: "Startup",
+	5: "Startup",
+	6: "Startup",
+	7: "Running",
+	8: "Standby",
+	9: "Bootloading",
+	10: "Error",
+	11: "Idle",
+	12: "Ready",
+	13: "Sleeping",
+	255: "Unknown",
+};
+
+function parseStatusCode(code) {
+	if (code === undefined || code === null) return "Unknown";
+	if (typeof code === "string") return code;
+	return STATUS_CODE_MAP[code] ?? "Unknown";
+}
+
+function parseErrorCode(code) {
+	if (code === undefined || code === null || code === 0) return "No error";
+	return `Error ${code}`;
+}
+
 class Inverter extends FroniusDevice {
 	/**
 	 * onInit is called when the device is initialized.
@@ -14,6 +44,20 @@ class Inverter extends FroniusDevice {
 				`Adding capability measure_frequency to device ${this.getName()}`,
 			);
 			this.addCapability("measure_frequency");
+		}
+
+		if (!this.hasCapability("fronius_inverter_state")) {
+			console.log(
+				`Adding capability fronius_inverter_state to device ${this.getName()}`,
+			);
+			this.addCapability("fronius_inverter_state");
+		}
+		
+		if (!this.hasCapability("fronius_error_code")) {
+			console.log(
+				`Adding capability fronius_error_code to device ${this.getName()}`,
+			);
+			this.addCapability("fronius_error_code");
 		}
 
 		//checking if DT is GEN24 or Tauro
@@ -155,6 +199,23 @@ class Inverter extends FroniusDevice {
 			"measure_frequency",
 			typeof data.FAC === "undefined" ? 0 : data.FAC.Value,
 		).catch(this.error);
+		//DeviceStatus: human-readable inverter state and error
+		const status = data.DeviceStatus;
+		if (status && this.hasCapability("fronius_inverter_state")) {
+			const stateText =
+				typeof status.InverterState === "string"
+					? status.InverterState
+					: parseStatusCode(status.StatusCode);
+			this.setCapabilityValue("fronius_inverter_state", stateText).catch(
+				this.error,
+			);
+		}
+		if (status && this.hasCapability("fronius_error_code")) {
+			const errorText = parseErrorCode(status.ErrorCode);
+			this.setCapabilityValue("fronius_error_code", errorText).catch(
+				this.error,
+			);
+		}
 	}
 }
 

--- a/drivers/inverter/driver.compose.json
+++ b/drivers/inverter/driver.compose.json
@@ -19,7 +19,9 @@
 		"measure_frequency",
 		"meter_power",
 		"meter_power.YEAR",
-		"meter_power.TOTAL"
+		"meter_power.TOTAL",
+		"fronius_inverter_state",
+		"fronius_error_code"
 	],
 	"capabilitiesOptions": {
 		"meter_power": {
@@ -63,6 +65,12 @@
 		},
 		"measure_frequency": {
 			"title": { "en": "Phase frequency" }
+		},
+		"fronius_inverter_state": {
+			"title": { "en": "Inverter state" }
+		},
+		"fronius_error_code": {
+			"title": { "en": "Error code" }
 		}
 	},
 	"images": {

--- a/tests/drivers/fronius-powerflow/device.test.js
+++ b/tests/drivers/fronius-powerflow/device.test.js
@@ -15,6 +15,9 @@ class TestPowerFlow extends PowerFlow {
 			"measure_power.LOAD",
 			"measure_power.GRID",
 			"measure_power.AKKU",
+			"fronius_backup_mode",
+			"fronius_autonomy",
+			"fronius_self_consumption",
 		]);
 		this._capabilityValues = new Map();
 		this._settings = {
@@ -146,6 +149,8 @@ describe("PowerFlow", () => {
 				P_Load: -3000,
 				P_Grid: -2000,
 				P_Akku: 500,
+				rel_Autonomy: 80.5,
+				rel_SelfConsumption: 67.3,
 			};
 
 			device.updateValues(data);
@@ -154,6 +159,8 @@ describe("PowerFlow", () => {
 			expect(device.getCapabilityValue("measure_power.LOAD")).toBe(-3000);
 			expect(device.getCapabilityValue("measure_power.GRID")).toBe(-2000);
 			expect(device.getCapabilityValue("measure_power.AKKU")).toBe(500);
+			expect(device.getCapabilityValue("fronius_autonomy")).toBe(80.5);
+			expect(device.getCapabilityValue("fronius_self_consumption")).toBe(67.3);
 		});
 
 		it("should calculate measure_power as grid + battery", () => {
@@ -180,6 +187,8 @@ describe("PowerFlow", () => {
 			expect(device.getCapabilityValue("measure_power.GRID")).toBe(0);
 			expect(device.getCapabilityValue("measure_power.AKKU")).toBe(0);
 			expect(device.getCapabilityValue("measure_power")).toBe(0);
+			expect(device.getCapabilityValue("fronius_autonomy")).toBe(0);
+			expect(device.getCapabilityValue("fronius_self_consumption")).toBe(0);
 		});
 
 		it("should handle null values with default 0", () => {
@@ -188,6 +197,8 @@ describe("PowerFlow", () => {
 				P_Load: null,
 				P_Grid: null,
 				P_Akku: null,
+				rel_Autonomy: null,
+				rel_SelfConsumption: null,
 			};
 
 			device.updateValues(data);
@@ -197,6 +208,8 @@ describe("PowerFlow", () => {
 			expect(device.getCapabilityValue("measure_power.GRID")).toBe(0);
 			expect(device.getCapabilityValue("measure_power.AKKU")).toBe(0);
 			expect(device.getCapabilityValue("measure_power")).toBe(0);
+			expect(device.getCapabilityValue("fronius_autonomy")).toBe(0);
+			expect(device.getCapabilityValue("fronius_self_consumption")).toBe(0);
 		});
 
 		it("should handle mixed null and valid values", () => {
@@ -214,6 +227,47 @@ describe("PowerFlow", () => {
 			expect(device.getCapabilityValue("measure_power.GRID")).toBe(-2000);
 			expect(device.getCapabilityValue("measure_power.AKKU")).toBe(0);
 			expect(device.getCapabilityValue("measure_power")).toBe(-2000);
+		});
+
+		it("should set BackupMode to false when grid-connected", () => {
+			const data = {
+				P_PV: 5000,
+				P_Load: -3000,
+				P_Grid: -2000,
+				P_Akku: 0,
+				BackupMode: false,
+			};
+
+			device.updateValues(data);
+
+			expect(device.getCapabilityValue("fronius_backup_mode")).toBe(false);
+		});
+
+		it("should set BackupMode to true when in backup mode", () => {
+			const data = {
+				P_PV: 1000,
+				P_Load: -500,
+				P_Grid: null,
+				P_Akku: -500,
+				BackupMode: true,
+			};
+
+			device.updateValues(data);
+
+			expect(device.getCapabilityValue("fronius_backup_mode")).toBe(true);
+		});
+
+		it("should set BackupMode to false when undefined", () => {
+			const data = {
+				P_PV: 5000,
+				P_Load: -3000,
+				P_Grid: -2000,
+				P_Akku: 0,
+			};
+
+			device.updateValues(data);
+
+			expect(device.getCapabilityValue("fronius_backup_mode")).toBe(false);
 		});
 	});
 

--- a/tests/drivers/inverter/device.test.js
+++ b/tests/drivers/inverter/device.test.js
@@ -447,4 +447,62 @@ describe("Inverter", () => {
 			expect(device.getCapabilityValue("meter_power.TOTAL")).toBe(100000000);
 		});
 	});
+
+	describe("updateValues - DeviceStatus", () => {
+		beforeEach(() => {
+			device._capabilities.add("fronius_inverter_state");
+			device._capabilities.add("fronius_error_code");
+		});
+
+		it("should set inverter state from InverterState string (GEN24)", () => {
+			const data = {
+				DeviceStatus: {
+					ErrorCode: 0,
+					InverterState: "Running",
+					StatusCode: 7,
+				},
+			};
+
+			device.updateValues(data);
+
+			expect(device.getCapabilityValue("fronius_inverter_state")).toBe(
+				"Running",
+			);
+			expect(device.getCapabilityValue("fronius_error_code")).toBe("No error");
+		});
+
+		it("should set inverter state from StatusCode when InverterState missing (Classic)", () => {
+			const data = {
+				DeviceStatus: {
+					ErrorCode: 0,
+					StatusCode: 7,
+				},
+			};
+
+			device.updateValues(data);
+
+			expect(device.getCapabilityValue("fronius_inverter_state")).toBe(
+				"Running",
+			);
+		});
+
+		it("should show error text when ErrorCode non-zero", () => {
+			const data = {
+				DeviceStatus: {
+					ErrorCode: 42,
+					StatusCode: 10,
+					InverterState: "Error",
+				},
+			};
+
+			device.updateValues(data);
+
+			expect(device.getCapabilityValue("fronius_error_code")).toBe(
+				"Error 42",
+			);
+			expect(device.getCapabilityValue("fronius_inverter_state")).toBe(
+				"Error",
+			);
+		});
+	});
 });

--- a/tests/drivers/storage/device.test.js
+++ b/tests/drivers/storage/device.test.js
@@ -13,6 +13,7 @@ class TestStorageDevice extends StorageDevice {
 			"measure_temperature",
 			"measure_battery",
 			"measure_power",
+			"battery_charging_state"
 		]);
 		this._capabilityValues = new Map();
 		this._settings = {


### PR DESCRIPTION
Adding the following new capabilities for the two fronius devices:

**Inverter**
- Inverter Status (String)
- Inverter Error Code

**PowerFlow**
- Backup Mode Active (Bolean)
- Autonomy (%)
- Self Consumption (%)


The values for these capabilities are provided via the Fronius Solar API (`GetInverterRealtimeData.cgi` and `GetPowerFlowRealtimeData.fcgi`).