### PR TITLE
Change Inverter Power to generated power

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Feel free to donate to  support the project !
 [<img src="https://www.paypalobjects.com/en_GB/i/btn/btn_donate_SM.gif">](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=RVBS24SPLU922&currency_code=EUR)
 
 # Version History
+### 0.1.21:
+	measure_power for inverters now reflects DC-side PV generation instead of AC output power, with PAC fallback when DC data is unavailable.
 ### 0.1.20:
 	Bugfix on doSubmit in pairing HTML files. Fixed typo in HTML files.
 ### 0.1.19:

--- a/drivers/inverter/device.js
+++ b/drivers/inverter/device.js
@@ -111,11 +111,76 @@ class Inverter extends FroniusDevice {
 				? 0
 				: data.TOTAL_ENERGY.Value / 1000,
 		).catch(this.error);
-		//AC power ; default to 0
-		this.setCapabilityValue(
-			"measure_power",
-			typeof data.PAC === "undefined" ? 0 : data.PAC.Value,
-		).catch(this.error);
+
+		// PV power (from DC side) for measure_power
+		const dt = this.getSetting("DT");
+		let mppt = this.getSetting("MPPTnumber");
+		if (!mppt || typeof mppt !== "number") mppt = 1;
+		if (dt !== 1) mppt = 1;
+
+		let pvPower = 0;
+		let hasDcData = false;
+
+		if (dt === 1) {
+			for (let i = 1; i <= mppt; i++) {
+				const currentField =
+					i === 1
+						? data.IDC
+						: data[`IDC_${i}`];
+				const voltageField =
+					i === 1
+						? data.UDC
+						: data[`UDC_${i}`];
+
+				const currentValue =
+					currentField && typeof currentField.Value === "number"
+						? currentField.Value
+						: undefined;
+				const voltageValue =
+					voltageField && typeof voltageField.Value === "number"
+						? voltageField.Value
+						: undefined;
+
+				if (
+					typeof currentValue === "number" &&
+					typeof voltageValue === "number"
+				) {
+					pvPower += currentValue * voltageValue;
+					hasDcData = true;
+				}
+			}
+		} else {
+			const currentField = data.IDC;
+			const voltageField = data.UDC;
+			const currentValue =
+				currentField && typeof currentField.Value === "number"
+					? currentField.Value
+					: undefined;
+			const voltageValue =
+				voltageField && typeof voltageField.Value === "number"
+					? voltageField.Value
+					: undefined;
+
+			if (
+				typeof currentValue === "number" &&
+				typeof voltageValue === "number"
+			) {
+				pvPower = currentValue * voltageValue;
+				hasDcData = true;
+			}
+		}
+
+		const acPowerField = data.PAC;
+		const acPowerValue =
+			acPowerField && typeof acPowerField.Value === "number"
+				? acPowerField.Value
+				: 0;
+
+		const measurePower = hasDcData ? pvPower : acPowerValue;
+
+		this.setCapabilityValue("measure_power", measurePower).catch(
+			this.error,
+		);
 		//AC current ; default to 0
 		this.setCapabilityValue(
 			"measure_current.AC",

--- a/tests/drivers/inverter/device.test.js
+++ b/tests/drivers/inverter/device.test.js
@@ -300,12 +300,29 @@ describe("Inverter", () => {
 			expect(device.getCapabilityValue("meter_power")).toBe(15);
 			expect(device.getCapabilityValue("meter_power.YEAR")).toBe(5000);
 			expect(device.getCapabilityValue("meter_power.TOTAL")).toBe(25000);
-			expect(device.getCapabilityValue("measure_power")).toBe(2500);
+			// PV power = UDC * IDC = 320 * 8.5 = 2720
+			expect(device.getCapabilityValue("measure_power")).toBe(2720);
 			expect(device.getCapabilityValue("measure_current.AC")).toBe(10.8);
 			expect(device.getCapabilityValue("measure_voltage.AC")).toBe(230);
 			expect(device.getCapabilityValue("measure_current.DC")).toBe(8.5);
 			expect(device.getCapabilityValue("measure_voltage.DC")).toBe(320);
 			expect(device.getCapabilityValue("measure_frequency")).toBe(50.02);
+		});
+
+		it("should fall back to PAC when DC data is missing", () => {
+			const data = {
+				DAY_ENERGY: { Value: 15000 },
+				YEAR_ENERGY: { Value: 5000000 },
+				TOTAL_ENERGY: { Value: 25000000 },
+				PAC: { Value: 2500 },
+				IAC: { Value: 10.8 },
+				UAC: { Value: 230 },
+				FAC: { Value: 50.02 },
+			};
+
+			device.updateValues(data);
+
+			expect(device.getCapabilityValue("measure_power")).toBe(2500);
 		});
 
 		it("should default to 0 for undefined fields", () => {
@@ -354,6 +371,8 @@ describe("Inverter", () => {
 			expect(device.getCapabilityValue("measure_voltage.DC")).toBe(350);
 			expect(device.getCapabilityValue("measure_current.DC2")).toBe(7.5);
 			expect(device.getCapabilityValue("measure_voltage.DC2")).toBe(345);
+			// PV power = sum(UDC_i * IDC_i) = 350*8.0 + 345*7.5 = 5387.5
+			expect(device.getCapabilityValue("measure_power")).toBe(5387.5);
 		});
 
 		it("should default MPPT values to 0 when undefined", () => {
@@ -367,6 +386,19 @@ describe("Inverter", () => {
 
 			expect(device.getCapabilityValue("measure_current.DC2")).toBe(0);
 			expect(device.getCapabilityValue("measure_voltage.DC2")).toBe(0);
+		});
+
+		it("should fall back to PAC when all DC data is missing", () => {
+			const data = {
+				PAC: { Value: 5000 },
+				IAC: { Value: 21.7 },
+				UAC: { Value: 230 },
+				FAC: { Value: 50.0 },
+			};
+
+			device.updateValues(data);
+
+			expect(device.getCapabilityValue("measure_power")).toBe(5000);
 		});
 
 		it("should not try to set meter_power when capability is removed", () => {


### PR DESCRIPTION
## Problem
The inverter’s reported power value (“PAC”) currently reflects only the AC output power.
In systems with an attached battery or storage unit, this becomes inaccurate because the PAC value includes battery discharge and excludes battery charging.

---
### Scenarios
**Daytime Scenario**
PV produces 5 kW
Battery charges with 2 kW
- The inverter PAC reports only 3 kW (5 kW − 2 kW)
- The inverter therefore shows less power than the PV system actually generates.

**Nighttime Scenario**
PV produces 0 kW
Battery discharges with 2 kW
- The inverter PAC reports 2 kW (0 kW + 2 kW)
- The inverter therefore shows more power than the PV system actually generates.

---
### Impact on the Energy Tab
This is especially problematic because the Homey Energy tab uses the inverter’s reported generation value to estimate:
- total PV production
- household energy consumption
- money saved

With the current PAC-based reporting, all of these values become inaccurate.

Additionally, because the battery/storage is also shown in the Energy tab:

- Discharged energy at night is counted twice in the power flow.
- Charged energy during the day effectively disappears from the power flow.

---
## Solution
The actual PV production will now be estimated by summing the power of all MPP strings reported by the inverter.
This approach resolves the issues described above.

The only drawback is that inverter losses are now included, meaning the calculated PV power will be slightly overestimated. In my opinion, this is acceptable because the cumulative PV energy is still reported separately by the inverter and is not affected by this estimation method.