### PR TITLE
Add commulative reporting for storage

### DIFF
--- a/app.json
+++ b/app.json
@@ -797,7 +797,10 @@
         "measure_voltage",
         "measure_battery",
         "measure_temperature",
-        "battery_charging_state"
+        "battery_charging_state",
+        "meter_power",
+        "meter_power.charged",
+        "meter_power.discharged"
       ],
       "capabilitiesOptions": {
         "measure_current": {
@@ -822,10 +825,27 @@
         },
         "measure_power": {
           "approximated": true
+        },
+        "meter_power": {
+          "title": {
+            "en": "Total throughput"
+          }
+        },
+        "meter_power.charged": {
+          "title": {
+            "en": "Charged energy"
+          }
+        },
+        "meter_power.discharged": {
+          "title": {
+            "en": "Discharged energy"
+          }
         }
       },
       "energy": {
-        "homeBattery": true
+        "homeBattery": true,
+        "meterPowerImportedCapability": "meter_power.charged",
+        "meterPowerExportedCapability": "meter_power.discharged"
       },
       "images": {
         "large": "/drivers/storage/assets/images/large.png",

--- a/drivers/storage/device.js
+++ b/drivers/storage/device.js
@@ -14,12 +14,28 @@ class StorageDevice extends FroniusDevice {
 			this.addCapability("battery_charging_state");
 		}
 
-		// Remove deprecated meter_power capability
-		if (this.hasCapability("meter_power")) {
-			console.log(
-				`Removing deprecated capability meter_power from device ${this.getName()}`,
-			);
-			this.removeCapability("meter_power");
+		// Ensure cumulative energy capabilities exist for storage devices
+		const energyCapabilities = [
+			"meter_power",
+			"meter_power.charged",
+			"meter_power.discharged",
+		];
+		for (const cap of energyCapabilities) {
+			if (!this.hasCapability(cap)) {
+				console.log(
+					`Adding capability ${cap} to device ${this.getName()}`,
+				);
+				this.addCapability(cap);
+			}
+		}
+
+		// Initialize cumulative energy counters from stored values (lifetime kWh)
+		for (const key of energyCapabilities) {
+			const storedValue = this.getStoreValue(key);
+			const value = typeof storedValue === "number" && storedValue >= 0
+				? storedValue
+				: 0;
+			this.setCapabilityValue(key, value).catch(this.error);
 		}
 
 		// Enable device polling
@@ -68,8 +84,50 @@ class StorageDevice extends FroniusDevice {
 				? 0
 				: data.Controller.StateOfCharge_Relative,
 		);
-		//power approximation
-		this.setCapabilityValue("measure_power", voltage * current);
+
+		// power approximation (W)
+		const power = voltage * current;
+		this.setCapabilityValue("measure_power", power);
+
+		// integrate power over polling interval to get cumulative energy in kWh
+		let intervalSeconds = this.getSetting("polling_interval");
+		if (typeof intervalSeconds !== "number" || intervalSeconds <= 0) {
+			intervalSeconds = 60;
+		}
+
+		const absPower = Math.abs(power);
+		const deltaKwhTotal = (absPower * intervalSeconds) / 3600 / 1000;
+		const deltaKwhImported = power > 0 ? deltaKwhTotal : 0;
+		const deltaKwhExported = power < 0 ? deltaKwhTotal : 0;
+
+		const currentTotal =
+			typeof this.getStoreValue("meter_power") === "number"
+				? this.getStoreValue("meter_power")
+				: 0;
+		const currentImported =
+			typeof this.getStoreValue("meter_power.charged") === "number"
+				? this.getStoreValue("meter_power.charged")
+				: 0;
+		const currentExported =
+			typeof this.getStoreValue("meter_power.discharged") === "number"
+				? this.getStoreValue("meter_power.discharged")
+				: 0;
+
+		const newTotal = Math.max(0, currentTotal + deltaKwhTotal);
+		const newImported = Math.max(0, currentImported + deltaKwhImported);
+		const newExported = Math.max(0, currentExported + deltaKwhExported);
+
+		this.setStoreValue("meter_power", newTotal).catch(this.error);
+		this.setStoreValue("meter_power.charged", newImported).catch(this.error);
+		this.setStoreValue("meter_power.discharged", newExported).catch(this.error);
+
+		this.setCapabilityValue("meter_power", newTotal).catch(this.error);
+		this.setCapabilityValue("meter_power.charged", newImported).catch(
+			this.error,
+		);
+		this.setCapabilityValue("meter_power.discharged", newExported).catch(
+			this.error,
+		);
 	}
 }
 

--- a/drivers/storage/driver.compose.json
+++ b/drivers/storage/driver.compose.json
@@ -10,7 +10,10 @@
 		"measure_voltage",
 		"measure_battery",
 		"measure_temperature",
-		"battery_charging_state"
+		"battery_charging_state",
+		"meter_power",
+		"meter_power.charged",
+		"meter_power.discharged"
 	],
 	"capabilitiesOptions": {
 		"measure_current": {
@@ -27,10 +30,21 @@
 		},
 		"measure_power": {
 			"approximated": true
+		},
+		"meter_power": {
+			"title": { "en": "Total throughput" }
+		},
+		"meter_power.charged": {
+			"title": { "en": "Charged energy" }
+		},
+		"meter_power.discharged": {
+			"title": { "en": "Discharged energy" }
 		}
 	},
 	"energy": {
-		"homeBattery": true
+		"homeBattery": true,
+		"meterPowerImportedCapability": "meter_power.charged",
+		"meterPowerExportedCapability": "meter_power.discharged"
 	},
 	"images": {
 		"large": "/drivers/storage/assets/images/large.png",

--- a/tests/drivers/storage/device.test.js
+++ b/tests/drivers/storage/device.test.js
@@ -13,6 +13,10 @@ class TestStorageDevice extends StorageDevice {
 			"measure_temperature",
 			"measure_battery",
 			"measure_power",
+			"battery_charging_state",
+			"meter_power",
+			"meter_power.charged",
+			"meter_power.discharged",
 		]);
 		this._capabilityValues = new Map();
 		this._settings = {
@@ -21,6 +25,7 @@ class TestStorageDevice extends StorageDevice {
 			polling_interval: 300,
 		};
 		this._listeners = new Map();
+		this._store = new Map();
 		this.polling = false;
 	}
 
@@ -51,6 +56,13 @@ class TestStorageDevice extends StorageDevice {
 	}
 	getName() {
 		return "Test Storage";
+	}
+	getStoreValue(key) {
+		return this._store.get(key);
+	}
+	setStoreValue(key, value) {
+		this._store.set(key, value);
+		return Promise.resolve();
 	}
 	log() {}
 	error() {}
@@ -102,20 +114,23 @@ describe("StorageDevice", () => {
 			expect(device.hasCapability("battery_charging_state")).toBe(true);
 		});
 
-		it("should remove deprecated meter_power capability", async () => {
-			device._capabilities.add("meter_power");
+		it("should ensure cumulative energy capabilities exist and initialize from store", async () => {
+			device._capabilities.delete("meter_power");
+			device._capabilities.delete("meter_power.charged");
+			device._capabilities.delete("meter_power.discharged");
+			device._store.set("meter_power", 1.5);
+			device._store.set("meter_power.charged", 1.0);
+			device._store.set("meter_power.discharged", 0.5);
 			device.pollDevice = vi.fn();
 
 			await device.onInit();
 
-			expect(device.hasCapability("meter_power")).toBe(false);
-		});
-
-		it("should not throw if meter_power not present", async () => {
-			device._capabilities.delete("meter_power");
-			device.pollDevice = vi.fn();
-
-			await expect(device.onInit()).resolves.not.toThrow();
+			expect(device.hasCapability("meter_power")).toBe(true);
+			expect(device.hasCapability("meter_power.charged")).toBe(true);
+			expect(device.hasCapability("meter_power.discharged")).toBe(true);
+			expect(device.getCapabilityValue("meter_power")).toBe(1.5);
+			expect(device.getCapabilityValue("meter_power.charged")).toBe(1.0);
+			expect(device.getCapabilityValue("meter_power.discharged")).toBe(0.5);
 		});
 
 		it("should enable polling", async () => {
@@ -299,6 +314,58 @@ describe("StorageDevice", () => {
 			expect(device.getCapabilityValue("measure_battery")).toBe(0);
 			expect(device.getCapabilityValue("measure_power")).toBe(0);
 			expect(device.getCapabilityValue("battery_charging_state")).toBe("idle");
+		});
+	});
+
+	describe("updateValues - cumulative energy", () => {
+		it("should accumulate imported, exported and total energy for positive power", () => {
+			// 48.5 V * 5.2 A = 252.2 W, interval 300 s => ~0.0210 kWh per call
+			const data = {
+				Controller: {
+					Voltage_DC: 48.5,
+					Current_DC: 5.2,
+					Temperature_Cell: 25,
+					StateOfCharge_Relative: 75,
+				},
+			};
+
+			device.updateValues(data);
+			device.updateValues(data);
+
+			const total = device.getCapabilityValue("meter_power");
+			const imported = device.getCapabilityValue("meter_power.charged");
+			const exported = device.getCapabilityValue("meter_power.discharged");
+
+			const expectedDeltaPerCall = (252.2 * 300) / 3600 / 1000;
+
+			expect(total).toBeCloseTo(2 * expectedDeltaPerCall, 5);
+			expect(imported).toBeCloseTo(2 * expectedDeltaPerCall, 5);
+			expect(exported).toBeCloseTo(0, 5);
+		});
+
+		it("should accumulate exported and total energy for negative power", () => {
+			const data = {
+				Controller: {
+					Voltage_DC: 48.5,
+					Current_DC: -3.0,
+					Temperature_Cell: 25,
+					StateOfCharge_Relative: 50,
+				},
+			};
+
+			device.updateValues(data);
+			device.updateValues(data);
+
+			const total = device.getCapabilityValue("meter_power");
+			const imported = device.getCapabilityValue("meter_power.charged");
+			const exported = device.getCapabilityValue("meter_power.discharged");
+
+			// 48.5 * 3.0 = 145.5 W
+			const expectedDeltaPerCall = (145.5 * 300) / 3600 / 1000;
+
+			expect(total).toBeCloseTo(2 * expectedDeltaPerCall, 5);
+			expect(exported).toBeCloseTo(2 * expectedDeltaPerCall, 5);
+			expect(imported).toBeCloseTo(0, 5);
 		});
 	});
 });


### PR DESCRIPTION
Add cumulative power reporting for power throughput, power charged, and power discharged for the Fronius storage/battery system.

These values will also be displayed in the Homey Energy tab.

## Calculation
The cumulative power is not directly provided via the Fornius Solar API by the storage system. Instead, it is derived from the calculated battery power, which itself is obtained from `Voltage_DC` * `Current_DC` fetched from `GetStorageRealtimeData`.

During each successful polling interval, the instantaneous power is integrated over the polling duration and added to the cumulative power counters.

- The absolute value (ignoring the sign) is added to `measure_power`.
- If the value is positive, it is added to `measure_power.charged`.
- If the value is negative, it is added to `measure_power.discharged`.